### PR TITLE
Fix space sent as first character of every prompt

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -164,9 +164,7 @@ class Florence2Run:
         if (task not in ['referring_expression_segmentation', 'caption_to_phrase_grounding', 'docvqa']) and text_input:
             raise ValueError("Text input (prompt) is only supported for 'referring_expression_segmentation', 'caption_to_phrase_grounding', and 'docvqa'")
 
-        prompt = task_prompt
-        if text_input != "":
-            prompt += text_input
+        prompt = f"{task_prompt}{text_input}"
 
         image = image.permute(0, 3, 1, 2)
         


### PR DESCRIPTION
Model does not remove the additional space inserted after prompt task tag.