### PR TITLE
Add bbox_count output.

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -362,8 +362,8 @@ class Florence2Run:
             }
         }
     
-    RETURN_TYPES = ("IMAGE", "MASK", "STRING", "JSON")
-    RETURN_NAMES =("image", "mask", "caption", "data") 
+    RETURN_TYPES = ("IMAGE", "MASK", "STRING", "JSON", "INT")
+    RETURN_NAMES =("image", "mask", "caption", "data", "bbox_count")
     FUNCTION = "encode"
     CATEGORY = "Florence2"
 
@@ -427,6 +427,7 @@ class Florence2Run:
         out_masks = []
         out_results = []
         out_data = []
+        bbox_count = 0
         pbar = ProgressBar(len(image))
         for img in image:
             image_pil = F.to_pil_image(img)
@@ -469,6 +470,7 @@ class Florence2Run:
                 ax.imshow(image_pil)
                 bboxes = parsed_answer[task_prompt]['bboxes']
                 labels = parsed_answer[task_prompt]['labels']
+                bbox_count += len(bboxes)
 
                 mask_indexes = []
                 # Determine mask indexes outside the loop
@@ -645,7 +647,8 @@ class Florence2Run:
                 overlay = Image.new('RGBA', image_pil.size, (255, 255, 255, 0))
                 draw = ImageDraw.Draw(overlay)
                 bboxes, labels = predictions['quad_boxes'], predictions['labels']
-                
+                bbox_count += len(bboxes)
+
                 # Create a new black image for the mask
                 mask_image = Image.new('RGB', (W, H), 'black')
                 mask_draw = ImageDraw.Draw(mask_image)
@@ -737,7 +740,7 @@ class Florence2Run:
             model.to(offload_device)
             mm.soft_empty_cache()
         
-        return (out_tensor, out_mask_tensor, out_results, out_data)
+        return (out_tensor, out_mask_tensor, out_results, out_data, bbox_count)
      
 NODE_CLASS_MAPPINGS = {
     "DownloadAndLoadFlorence2Model": DownloadAndLoadFlorence2Model,


### PR DESCRIPTION
Simply put: adds an output with the bbox_count.

<img width="1284" height="426" alt="Screenshot 2026-02-14 at 10 01 56" src="https://github.com/user-attachments/assets/c3718a40-baf8-4adf-b4b4-93738b8398a4" />

<img width="1039" height="639" alt="Screenshot 2026-02-14 at 10 18 48" src="https://github.com/user-attachments/assets/79baa549-1b42-49ee-944c-3b1bfd652067" />

Full workflow with a loop: https://gist.github.com/yungYEEZY/059100aa30378f12b6c4ac4d0bec8cf7
Based on https://openart.ai/workflows/risunobushi/iterative-object-remover---automated-with-loops/rqnVmKquh6e8QdnPNqjf